### PR TITLE
optimized_weights_computation_reg

### DIFF
--- a/3drpp_appx/include/traverser.h
+++ b/3drpp_appx/include/traverser.h
@@ -10,6 +10,7 @@ using PeriodicInteractionPair = std::pair<int, std::pair<int, vec3r>>;
 using InteractionPairs = std::vector<InteractionPair>;
 using PeriodicInteractionPairs = std::vector<PeriodicInteractionPair>;
 
+using PeriodicInteractionMapP2P = std::vector<std::vector<std::pair<int, vec3r>>>;
 using PeriodicInteractionMap = std::map<int, std::vector<std::pair<int, vec3r>>>;
 
 
@@ -47,7 +48,9 @@ public:
 
     PeriodicInteractionPairs get_pairs(OperatorType type);
 
-    PeriodicInteractionMap get_map(OperatorType type);
+    rtfmm::PeriodicInteractionMap get_m2l_map();
+
+    rtfmm::PeriodicInteractionMapP2P get_p2p_map();
 
     PeriodicM2LMap get_M2L_parent_map();
 
@@ -97,7 +100,7 @@ public:
     PeriodicInteractionPairs P2L_pairs;
 
     PeriodicInteractionMap M2L_map;
-    PeriodicInteractionMap P2P_map;
+    PeriodicInteractionMapP2P P2P_map;
 
     //PeriodicInteractionMap M2L_parent_map;
     PeriodicM2LMap M2L_parent_map;

--- a/3drpp_appx/include/tree.h
+++ b/3drpp_appx/include/tree.h
@@ -9,6 +9,7 @@ namespace rtfmm
 struct Cell3
 {
     int idx;
+    int leaf_idx; // if cell is leaf then a valid id otherwise -1
     /**
      * @brief octant relative to parent cell
      * @note 
@@ -35,6 +36,7 @@ struct Cell3
     {
         M = 0;
         L = 0;
+        leaf_idx = -1;
     }
 
     friend std::ostream &operator<<(std::ostream & os, const Cell3 & cell) 

--- a/3drpp_appx/src/fmm.cpp
+++ b/3drpp_appx/src/fmm.cpp
@@ -36,9 +36,9 @@ rtfmm::Bodies3 rtfmm::LaplaceFMM::solve()
 
     tbegin(init_cell_matrix);
     init_cell_matrix(cs);
-    tbegin(init_reg_body_time);
+    tbegin(init_reg_body_func);
     init_reg_body(cs); // init body index in image-1 cells
-    tend(init_reg_body_time);
+    tend(init_reg_body_func);
     tend(init_cell_matrix);
 
     if(args.use_precompute)
@@ -334,11 +334,14 @@ void rtfmm::LaplaceFMM::init_reg_body(Cells3& cells)
                     (body.x - args.x).abs() + args.rega;
                 vec3r ws = get_w_xyz(dx, cell.r, args.rega);
 
-                for (int d = 0; d <= 2; d++)
+                if(args.images == 0)
                 {
-                    if (dx_simcenter[d] >= args.r)
+                    for (int d = 0; d <= 2; d++)
                     {
-                        ws[d] = 1;
+                        if (dx_simcenter[d] >= args.r)
+                        {
+                            ws[d] = 1;
+                        }
                     }
                 }
                 const real w = ws.mul();

--- a/3drpp_appx/src/traverser.cpp
+++ b/3drpp_appx/src/traverser.cpp
@@ -21,6 +21,18 @@ void rtfmm::Traverser::traverse(Tree& tree, real cycle, int images, int P_)
 {
     P = P_;
     cells = tree.get_cells();
+    int leaf_id = 0;
+    for(int i = 0; i < cells.size(); i++)
+    {
+        if(cells[i].crange.number == 0)
+        {
+            leaf_cell_idx.push_back(i);
+            cells[i].leaf_idx = leaf_id;
+            leaf_id++;
+        }
+    }
+
+    P2P_map.resize(leaf_cell_idx.size());
     if(images == 0)
     {
         if(verbose) printf("horizontal_origin\n");
@@ -68,13 +80,8 @@ void rtfmm::Traverser::traverse(Tree& tree, real cycle, int images, int P_)
         }
     }
 
-    for(int i = 0; i < cells.size(); i++)
-    {
-        if(cells[i].crange.number == 0)
-        {
-            leaf_cell_idx.push_back(i);
-        }
-    }
+
+    
 }
 
 void rtfmm::Traverser::horizontal_origin(int tc, int sc, int tcp, int scp, vec3r offset)
@@ -86,7 +93,7 @@ void rtfmm::Traverser::horizontal_origin(int tc, int sc, int tcp, int scp, vec3r
         {
             if(is_leaf(sc) && cells[sc].bodies.size() <= get_surface_point_num(P))
             {
-                P2P_map[tc].push_back(std::make_pair(sc, offset));
+                P2P_map[cells[tc].leaf_idx].push_back(std::make_pair(sc, offset));
             }
             else
             {
@@ -98,7 +105,7 @@ void rtfmm::Traverser::horizontal_origin(int tc, int sc, int tcp, int scp, vec3r
         {
             if(is_leaf(tc) && cells[tc].bodies.size() <= get_surface_point_num(P))
             {
-                P2P_map[tc].push_back(std::make_pair(sc, offset));
+                P2P_map[cells[tc].leaf_idx].push_back(std::make_pair(sc, offset));
             }
             else
             {
@@ -113,11 +120,12 @@ void rtfmm::Traverser::horizontal_origin(int tc, int sc, int tcp, int scp, vec3r
         }
         else
         {
-            if(is_leaf(tc) && is_leaf(sc))
-            {
-                printf("here\n");
-            }
-            else if(!is_leaf(tc) && is_leaf(sc))
+            // if(is_leaf(tc) && is_leaf(sc))
+            // {
+            //     printf("here\n");
+            // }
+            // else
+            if(!is_leaf(tc) && is_leaf(sc))
             {
                 divide = 1;
             }
@@ -135,7 +143,7 @@ void rtfmm::Traverser::horizontal_origin(int tc, int sc, int tcp, int scp, vec3r
     {
         if(is_leaf(tc) && is_leaf(sc))
         {
-            P2P_map[tc].push_back(std::make_pair(sc, offset));
+            P2P_map[cells[tc].leaf_idx].push_back(std::make_pair(sc, offset));
         }
         else if(!is_leaf(tc) && is_leaf(sc))
         {
@@ -363,14 +371,14 @@ rtfmm::PeriodicInteractionPairs rtfmm::Traverser::get_pairs(OperatorType type)
     }
 }
 
-rtfmm::PeriodicInteractionMap rtfmm::Traverser::get_map(OperatorType type)
+rtfmm::PeriodicInteractionMap rtfmm::Traverser::get_m2l_map()
 {
-    switch(type)
-    {
-        case OperatorType::M2L : return M2L_map; break;
-        case OperatorType::P2P : return P2P_map; break;
-        default: return PeriodicInteractionMap();
-    }
+    return M2L_map;
+}
+
+rtfmm::PeriodicInteractionMapP2P rtfmm::Traverser::get_p2p_map()
+{
+    return P2P_map;
 }
 
 rtfmm::PeriodicM2LMap rtfmm::Traverser::get_M2L_parent_map()


### PR DESCRIPTION
I suggest certain changes to weight computations for p2p phase (specifically init_reg_body function inside fmm.cpp).

Currently, We iterate over all the bodies to see if each body influences some cells. This is an exhaustive way of doing that.

I now pick a target cell and just see the bodies in its neighbouring cells if they have some influence on the target cell. This avoids looking into all leaf cells, which slows down computation particularly as the number of particles grows.

Also, I consider only those bodies for regularization which doesn't have weight one in their own cell.

I have tried a few experiments with this update on my workstation:

`./test_reg -n 33876 -P 6 -m 16 -a fd -r 0.01`

`init_reg_body `time is reduced from `0.47098` to `0.00800` seconds

`./test/test_reg -n 120000 -P 6 -m 16 -a fd -r 0.01`

`init_reg_body `time is reduced from `12.26815` to `0.05770` seconds

