### PR TITLE
simplified init_reg_body function to remove extra loop over periodic cells

### DIFF
--- a/3drpp_appx/include/kernel.h
+++ b/3drpp_appx/include/kernel.h
@@ -80,13 +80,13 @@ public:
      * we don't need to distinguish non-periodic/periodic cells in hadamard product stage(but the scale is different at the final store stage).
      * @note 2nd fast
     */
-    void m2l_fft_precompute_advanced2(int P, Cells3& cs, PeriodicInteractionMap& m2l_map);
+    void m2l_fft_precompute_advanced2(int P, Cells3& cs, PeriodicInteractionMapM2L& m2l_map);
 
     /**
      * @brief Hadamard transposed version of m2l_fft_precompute_advanced2, frequency-wise parallelization.
      * @note 3rd fast
     */
-    void m2l_fft_precompute_advanced3(int P, Cells3& cs, PeriodicInteractionMap& m2l_map, PeriodicInteractionPairs& m2l_pairs);
+    void m2l_fft_precompute_advanced3(int P, Cells3& cs, PeriodicInteractionMapM2L& m2l_map, PeriodicInteractionPairs& m2l_pairs);
 
     /**
      * @brief M2L with FFT like exafmm-t.
@@ -112,7 +112,7 @@ public:
 
     void precompute(int P, real r0, int images);
 
-    void precompute_m2l(int P, real r0, Cells3 cs, PeriodicInteractionMap m2l_map, int images);
+    void precompute_m2l(int P, real r0, Cells3 cs, PeriodicInteractionMapM2L m2l_map, int images);
 
     Matrix get_p2p_matrix(
         std::vector<vec3r>& x_src, 

--- a/3drpp_appx/include/traverser.h
+++ b/3drpp_appx/include/traverser.h
@@ -11,7 +11,7 @@ using InteractionPairs = std::vector<InteractionPair>;
 using PeriodicInteractionPairs = std::vector<PeriodicInteractionPair>;
 
 using PeriodicInteractionMapP2P = std::vector<std::vector<std::pair<int, vec3r>>>;
-using PeriodicInteractionMap = std::map<int, std::vector<std::pair<int, vec3r>>>;
+using PeriodicInteractionMapM2L = std::map<int, std::vector<std::pair<int, vec3r>>>;
 
 
 struct PeriodicParentSource
@@ -48,7 +48,7 @@ public:
 
     PeriodicInteractionPairs get_pairs(OperatorType type);
 
-    rtfmm::PeriodicInteractionMap get_m2l_map();
+    rtfmm::PeriodicInteractionMapM2L get_m2l_map();
 
     rtfmm::PeriodicInteractionMapP2P get_p2p_map();
 
@@ -56,7 +56,7 @@ public:
 
     Cells3 get_cells() {return cells;}
 
-    PeriodicInteractionMap get_m2l_map_from_m2l_parent_map();
+    PeriodicInteractionMapM2L get_m2l_map_from_m2l_parent_map();
 
 private:
     
@@ -99,10 +99,10 @@ public:
     PeriodicInteractionPairs M2P_pairs;
     PeriodicInteractionPairs P2L_pairs;
 
-    PeriodicInteractionMap M2L_map;
+    PeriodicInteractionMapM2L M2L_map;
     PeriodicInteractionMapP2P P2P_map;
 
-    //PeriodicInteractionMap M2L_parent_map;
+    //PeriodicInteractionMapM2L M2L_parent_map;
     PeriodicM2LMap M2L_parent_map;
 
     std::vector<int> leaf_cell_idx;

--- a/3drpp_appx/src/fmm.cpp
+++ b/3drpp_appx/src/fmm.cpp
@@ -143,9 +143,9 @@ void rtfmm::LaplaceFMM::M2L()
 {
     TIME_BEGIN(M2L);
     //PeriodicInteractionPairs m2l_pairs = traverser.get_pairs(OperatorType::M2L);
-    //PeriodicInteractionMap m2l_map = traverser.get_map(OperatorType::M2L);
+    //PeriodicInteractionMapM2L m2l_map = traverser.get_map(OperatorType::M2L);
     PeriodicM2LMap m2l_parent_map = traverser.get_M2L_parent_map();
-    //PeriodicInteractionMap m2l_map2 = traverser.get_m2l_map_from_m2l_parent_map();
+    //PeriodicInteractionMapM2L m2l_map2 = traverser.get_m2l_map_from_m2l_parent_map();
     if(args.use_precompute)
     {
         //kernel.m2l_fft_precompute_advanced2(args.P, cs, m2l_map2);
@@ -155,7 +155,7 @@ void rtfmm::LaplaceFMM::M2L()
     }
     else
     {
-        PeriodicInteractionMap m2l_map = traverser.get_m2l_map();
+        PeriodicInteractionMapM2L m2l_map = traverser.get_m2l_map();
         for(int i = 0; i < m2l_map.size(); i++)
         {
             auto m2l_list = m2l_map.begin();
@@ -371,77 +371,24 @@ void rtfmm::LaplaceFMM::init_reg_body(Cells3& cells)
             for (size_t j = 0; j < aCells.size(); j++)
             {
                 auto& adj_cell_info = aCells[j];
-                if (cell.x != cells[adj_cell_info.first].x)
+                if (cell.idx != cells[adj_cell_info.first].idx)
                 {
                     // check for regularization bodies from adjacent cells
                     for (const int &body_idx : boundary_bodies_idxs[cells[adj_cell_info.first].leaf_idx])
                     {
 
                         const Body3 &body = bs[body_idx];
-                        const vec3r dx = body.x - cell.x;
+                        const vec3r dx = body.x + adj_cell_info.second - cell.x;
                         const real w = get_w_xyz(dx, cell.r, args.rega).mul();
+
                         if (w > 0)
                         {
-                            cell.reg_body_idx.push_back(std::make_pair(body_idx, vec3r(0,0,0)));
+                            cell.reg_body_idx.push_back(std::make_pair(body_idx, adj_cell_info.second));
                         }
                     }
                 }
             }
         }
-
-         printf("search except 0,0,0\n");
-
-        // search reg body except 0,0,0
-        if(args.images > 0)
-        {
-            for(int x = -1; x <= 1; x++)
-            {
-                for(int y = -1; y <= 1; y++)
-                {
-                    for(int z = -1; z <= 1; z++)
-                    {
-                        if(x == 0 && y == 0 && z == 0)
-                            continue;
-
-
-                        vec3r region_offset = vec3r(x,y,z) * args.cycle;
-
-                        
-                        for(int leaf_idx = 0; leaf_idx < leaves.size(); leaf_idx++)
-                        {
-                            Cell3& cell = cells[leaves[leaf_idx]];
-                            const auto &aCells = p2p_map[cell.leaf_idx];
-            
-
-                            // find out bodies from adjacent cells that are influencing this cell
-                            for (size_t j = 0; j < aCells.size(); j++)
-                            {
-                                auto& adj_cell_info = aCells[j];
-                                if (cell.x != cells[adj_cell_info.first].x)
-                                {
-                                    // checkout for regularization bodies from adjacent cells
-                                    for (const int &body_idx : boundary_bodies_idxs[cells[adj_cell_info.first].leaf_idx])
-                                    {
-
-                                        const Body3 &body = bs[body_idx];
-                                        vec3r ploc = body.x + region_offset;
-                                        const vec3r dx = ploc - cell.x;
-                                        const real w = get_w_xyz(dx, cell.r, args.rega).mul();
-                                        if (w > 0)
-                                        {
-                                            cell.reg_body_idx.push_back(std::make_pair(body_idx, region_offset));
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-
-
         
         // compute weight and cache
         for(int leaf_idx = 0; leaf_idx < leaves.size(); leaf_idx++)
@@ -562,6 +509,7 @@ void rtfmm::LaplaceFMM::check_tree(const Cells3& cells)
 
 void rtfmm::LaplaceFMM::check_traverser(Traverser& traverser)
 {
+    std::cout << "I am doing it doesn't matter what\n";
     PeriodicInteractionPairs P2P_pairs = traverser.get_pairs(OperatorType::P2P);
     PeriodicInteractionPairs M2L_pairs = traverser.get_pairs(OperatorType::M2L);
     PeriodicInteractionPairs M2P_pairs = traverser.get_pairs(OperatorType::M2P);

--- a/3drpp_appx/src/fmm.cpp
+++ b/3drpp_appx/src/fmm.cpp
@@ -356,9 +356,6 @@ void rtfmm::LaplaceFMM::init_reg_body(Cells3& cells)
             }
         }
 
-
-
-        // cell.reg_body_idx
         PeriodicInteractionMapP2P p2p_map = traverser.get_p2p_map();
 
         for(int leaf_idx = 0; leaf_idx < leaves.size(); leaf_idx++)
@@ -509,7 +506,6 @@ void rtfmm::LaplaceFMM::check_tree(const Cells3& cells)
 
 void rtfmm::LaplaceFMM::check_traverser(Traverser& traverser)
 {
-    std::cout << "I am doing it doesn't matter what\n";
     PeriodicInteractionPairs P2P_pairs = traverser.get_pairs(OperatorType::P2P);
     PeriodicInteractionPairs M2L_pairs = traverser.get_pairs(OperatorType::M2L);
     PeriodicInteractionPairs M2P_pairs = traverser.get_pairs(OperatorType::M2P);

--- a/3drpp_appx/src/kernel.cpp
+++ b/3drpp_appx/src/kernel.cpp
@@ -747,7 +747,7 @@ void rtfmm::LaplaceKernel::m2l_fft_precompute_advanced(int P, Cells3& cs, Period
     TIME_END(destroy_plan);
 }
 
-void rtfmm::LaplaceKernel::m2l_fft_precompute_advanced2(int P, Cells3& cs, PeriodicInteractionMap& m2l_map)
+void rtfmm::LaplaceKernel::m2l_fft_precompute_advanced2(int P, Cells3& cs, PeriodicInteractionMapM2L& m2l_map)
 {
     if(verbose)
     {
@@ -880,7 +880,7 @@ void rtfmm::LaplaceKernel::m2l_fft_precompute_advanced2(int P, Cells3& cs, Perio
     TIME_END(down);
 }
 
-void rtfmm::LaplaceKernel::m2l_fft_precompute_advanced3(int P, Cells3& cs, PeriodicInteractionMap& m2l_map, PeriodicInteractionPairs& m2l_pairs)
+void rtfmm::LaplaceKernel::m2l_fft_precompute_advanced3(int P, Cells3& cs, PeriodicInteractionMapM2L& m2l_map, PeriodicInteractionPairs& m2l_pairs)
 {
     if(verbose) printf("m2l_fft_precompute_advanced3\n");
     int num_src = m2l_srcs.size();
@@ -1719,7 +1719,7 @@ void rtfmm::LaplaceKernel::precompute(int P, real r0, int images)
     VSinvUT_l2p_precompute = mat_mat_mul(VSinv_l2p_precompute, UT_l2p_precompute);
 }
 
-void rtfmm::LaplaceKernel::precompute_m2l(int P, real r0, Cells3 cs, PeriodicInteractionMap m2l_map, int images)
+void rtfmm::LaplaceKernel::precompute_m2l(int P, real r0, Cells3 cs, PeriodicInteractionMapM2L m2l_map, int images)
 {
     // for advanced2 and 3
     std::set<int> m2l_tar_set, m2l_src_set;

--- a/3drpp_appx/src/traverser.cpp
+++ b/3drpp_appx/src/traverser.cpp
@@ -310,10 +310,10 @@ void rtfmm::Traverser::make_M2L_parent_map_i1(real cycle)
     }
 }
 
-rtfmm::PeriodicInteractionMap rtfmm::Traverser::get_m2l_map_from_m2l_parent_map()
+rtfmm::PeriodicInteractionMapM2L rtfmm::Traverser::get_m2l_map_from_m2l_parent_map()
 {
     std::cout<<M2L_parent_map.size()<<std::endl;
-    PeriodicInteractionMap res;
+    PeriodicInteractionMapM2L res;
     for(auto m2l_parent : M2L_parent_map)
     {
         Cell3& ctar = cells[m2l_parent.first];
@@ -371,7 +371,7 @@ rtfmm::PeriodicInteractionPairs rtfmm::Traverser::get_pairs(OperatorType type)
     }
 }
 
-rtfmm::PeriodicInteractionMap rtfmm::Traverser::get_m2l_map()
+rtfmm::PeriodicInteractionMapM2L rtfmm::Traverser::get_m2l_map()
 {
     return M2L_map;
 }


### PR DESCRIPTION
Apart from some variable renaming,  There is one significant change to `init_reg_body` function. Since when working with pbc, p2p_map already contains periodic cells, we don't need a separate loop for handling periodic cells. I removed that loop and simplified the function.